### PR TITLE
Alter changeDisplay recipe, add hideRecipe function

### DIFF
--- a/main.js
+++ b/main.js
@@ -63,18 +63,24 @@ function displayRandomDish() {
 };
 
 function clearRecipe() {
-  changeDisplay();
+  hideRecipe();
   randomRecipeText.innerText = "";
 }
 
-function changeDisplay() {
-  imgCookPot.classList.toggle("hidden");
-  randomRecipeIntro.classList.toggle("hidden");
-  btnClear.classList.toggle("hidden");
+function hideRecipe() {
+  imgCookPot.classList.remove("hidden");
+  randomRecipeIntro.classList.add("hidden");
+  btnClear.classList.add("hidden");
+}
+
+function showRecipe() {
+  imgCookPot.classList.add("hidden");
+  randomRecipeIntro.classList.remove("hidden");
+  btnClear.classList.remove("hidden");
 };
 
 function displayRecipe() {
-  changeDisplay();
+  showRecipe();
   randomRecipeText.innerText = `${randomRecipe}!`
 };
 
@@ -83,7 +89,7 @@ function displayRecipeBar() {
 };
 
 function displayUserRecipe() {
-  changeDisplay();
+  showRecipe();
   randomRecipeText.innerText = `${inputUserRecipe.value}`;
 };
 


### PR DESCRIPTION
## Is this a fix or feature?
Fix

## What is the change?
Changed the "changeDisplay" function to "showDisplay" and took away the toggle method. Added a "hideDisplay" function. 

## What does it fix?
When the user clicked the "Let's cook" button, the cook pot would re-appear and disappear. Instead, the user should see another random recipe appear if button is clicked multiple times. The "add new" button also had the same issue, and the appropriate functions were added to the add new recipe bar. 

## Where should the reviewer start?

main.js lines 70-80

## How should this be tested?
- When clicking on the "Let's cook" button the recipe display should remain visible and a new random recipe should display if clicked multiple times. 
- When clicking the "add new" recipe, the user's recipe should display. If another recipe is added, the new recipe should then display when the button is clicked. 


