### PR TITLE
Add event listener to hide recipe bar

### DIFF
--- a/main.js
+++ b/main.js
@@ -27,6 +27,7 @@ btnAddRecipe.addEventListener("click", displayRecipeBar);
 btnAddNew.addEventListener("click", validateForm);
 btnClear.addEventListener("click", clearRecipe);
 formLogin.addEventListener("submit", login);
+recipeBar.addEventListener("dblclick", displayRecipeBar);
 
 function login(e) {
   e.preventDefault();
@@ -79,7 +80,7 @@ function displayRecipe() {
 };
 
 function displayRecipeBar() {
-  recipeBar.classList.remove("hidden");
+  recipeBar.classList.toggle("hidden");
 };
 
 function displayUserRecipe() {


### PR DESCRIPTION
## Is this a fix or feature?
feature

## What is the change?
This allows the user to double click on the recipe bar and the bar will be hidden again. 

## What does it fix?

## Where should the reviewer start?
main.js lines 30, 82-83

## How should this be tested?
When "Add a recipe" button is clicked, the recipe bar should pop up. Double click on the bar to make it disappear. 


